### PR TITLE
fix(playground): remaining space in http get request

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -39,7 +39,7 @@
         let sourceCode = window.editor.getValue()
         console.log(sourceCode)
         if (sourceCode) {
-          const jsonResponse = await fetch(`http://localhost:8000/trans/${sourceCode}`, {
+          const jsonResponse = await fetch(`http://localhost:8000/trans/${encodeURIComponent(sourceCode)}`, {
               method: 'GET', // or 'PUT'
              })
           const jsonData = await jsonResponse.text();


### PR DESCRIPTION
remain new line spacing from url encoding to show line number in target's comment.
e.g., 
<img width="736" alt="截圖 2022-06-25 上午11 33 51" src="https://user-images.githubusercontent.com/35886692/175756624-6acbe01c-b013-4f1c-9223-69735ef31846.png">

